### PR TITLE
prevents nil from appearing in `results`

### DIFF
--- a/lib/autosuggest.rb
+++ b/lib/autosuggest.rb
@@ -151,6 +151,9 @@ class Autosuggest
       result[:notes] = notes
       result
     end
+    
+    results.compact!
+    
     if filter
       results.reject! { |s| s[:duplicate] || s[:misspelling] || s[:profane] || s[:blocked] }
     end


### PR DESCRIPTION
Hi,

https://github.com/ankane/autosuggest/blob/master/lib/autosuggest.rb#L87 will add `nil` to the finished array which in turn will clash if `filter` is set to `true` here https://github.com/ankane/autosuggest/blob/master/lib/autosuggest.rb#L155.

Alternative solution if `nil` should still appear in unfiltered results:
```ruby
results.reject! { |s| s.nil? || s[:duplicate] || s[:misspelling] || s[:profane] || s[:blocked] }
```

Hope it helps